### PR TITLE
Replace Bio.SeqIO with pyfaidx.Fasta

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bokeh
-biopython
+pyfaidx
 tqdm
 click
 numpy

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ VERSION = "0.1.2"
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    "biopython", "click", "tqdm", "bokeh", "numpy", "python-box"
+    "click", "tqdm", "bokeh", "numpy", "python-box", "pyfaidx"
 ]
 
 # What packages are optional?

--- a/squiggle/cli.py
+++ b/squiggle/cli.py
@@ -1,7 +1,7 @@
 import math
 
 import click
-from Bio import SeqIO
+from pyfaidx import Fasta
 from tqdm import tqdm
 from box import Box
 
@@ -43,7 +43,7 @@ def visualize(fasta, width, palette, color, hide, bar, title, separate, cols, li
     if not dimensions:
         dimensions = (750, 500)
 
-    if len([record for _f in fasta for record in SeqIO.parse(_f, "fasta")]) > len(palette) and mode != "file":
+    if len([record for _f in fasta for record in Fasta(_f)]) > len(palette) and mode != "file":
         if len(fasta) > 1 and mode == "auto":
             if not skip:
                 print("Visualizing each file in separate color. To override, provide mode selection.")
@@ -59,7 +59,7 @@ def visualize(fasta, width, palette, color, hide, bar, title, separate, cols, li
     color_counter = 0
     warned = False
     for i, _f in enumerate(fasta):
-        for j, seq in enumerate(SeqIO.parse(_f, "fasta")):
+        for j, seq in enumerate(Fasta(_f)):
             seqs.append(Box(color=palette[color_counter + 1 if color_counter > 2 else 3][color_counter] if color else "black",
                             name=_f if mode == "file" else seq.name,
                             raw_seq=seq))

--- a/squiggle/cli.py
+++ b/squiggle/cli.py
@@ -59,7 +59,7 @@ def visualize(fasta, width, palette, color, hide, bar, title, separate, cols, li
     color_counter = 0
     warned = False
     for i, _f in enumerate(fasta):
-        for j, seq in enumerate(Fasta(_f)):
+        for j, seq in enumerate(Fasta(_f, sequence_always_upper=True)):
             seqs.append(Box(color=palette[color_counter + 1 if color_counter > 2 else 3][color_counter] if color else "black",
                             name=_f if mode == "file" else seq.name,
                             raw_seq=seq))
@@ -159,7 +159,7 @@ def visualize(fasta, width, palette, color, hide, bar, title, separate, cols, li
 
     for i, seq in enumerate(_seqs):
         # perform the actual transformation
-        transformed = transform(seq.raw_seq, method=method)
+        transformed = transform(str(seq.raw_seq), method=method)
 
         # figure (no pun intended) which figure to plot the data on
         if separate:
@@ -191,7 +191,7 @@ def visualize(fasta, width, palette, color, hide, bar, title, separate, cols, li
         if method == "randic":
             y = list(seq.raw_seq)
         elif method == "qi":
-            y = [seq.raw_seq[i:i + 2].seq for i in range(len(seq.raw_seq))]
+            y = [seq.raw_seq[i:i + 2] for i in range(len(seq.raw_seq))]
             y = [str(i) for i in y if len(i) == 2]
         else:
             y = transformed[1]


### PR DESCRIPTION
This is a really cool visualization method, and I noticed that you're really just using Biopython to read FASTA files, and the `Fasta` class from [pyfaidx](https://github.com/mdshw5/pyfaidx) might help with efficiency and code complexity.

For instance:

https://github.com/Lab41/squiggle/blob/master/squiggle/cli.py#L46-L50

You were checking the length of the sequences by reading them completely, when you can get that information from just the index file with `Fasta`. You're also checking sequence lengths in some other places as well. 

At the very least using FASTA index files should decrease memory usage for multifasta files, and potentially decrease runtime as well although there's a minimal difference with the current example files:

With pyfaidx:
```
time yes | squiggle example_seqs/*fasta
Visualizing each file in separate color. To override, provide mode selection.
                                                                                                                                                             
real	0m10.554s
user	0m9.558s
sys	0m0.530s
```

With Bio.SeqIO:
```
time yes | squiggle example_seqs/*fasta
Visualizing each file in separate color. To override, provide mode selection.
                                                                                                                                                             
real	0m10.840s
user	0m9.826s
sys	0m0.565s
```

The timings are with warm file caching, so the difference in timing is really down to Python object creation.